### PR TITLE
fix(attributes): handle missing attributes and duplicate key

### DIFF
--- a/custom_components/fpl/fplapi.py
+++ b/custom_components/fpl/fplapi.py
@@ -296,13 +296,15 @@ class FplApi(object):
                         ):
                             dailyUsage.append(
                                 {
-                                    "usage": daily["kwhUsed"],
-                                    "cost": daily["billingCharge"],
-                                    "date": daily["date"],
-                                    "max_temperature": daily["averageHighTemperature"],
-                                    "netDeliveredKwh": daily["netDeliveredKwh"],
-                                    "netReceivedKwh": daily["netReceivedKwh"],
-                                    "readTime": daily["readTime"],
+                                    "usage": daily.get("kwhUsed"),
+                                    "cost": daily.get("billingCharge"),
+                                    "date": daily.get("date"),
+                                    "max_temperature": daily.get(
+                                        "averageHighTemperature"
+                                    ),
+                                    "netDeliveredKwh": daily.get("netDeliveredKwh"),
+                                    "netReceivedKwh": daily.get("netReceivedKwh"),
+                                    "readTime": daily.get("readTime"),
                                 }
                             )
                             # totalPowerUsage += int(daily["kwhUsed"])
@@ -310,12 +312,12 @@ class FplApi(object):
                     # data["total_power_usage"] = totalPowerUsage
                     data["daily_usage"] = dailyUsage
 
-                data["projectedKWH"] = r["CurrentUsage"]["projectedKWH"]
-                data["dailyAverageKWH"] = r["CurrentUsage"]["dailyAverageKWH"]
-                data["billToDateKWH"] = r["CurrentUsage"]["billToDateKWH"]
-                data["recMtrReading"] = r["CurrentUsage"]["recMtrReading"]
-                data["delMtrReading"] = r["CurrentUsage"]["delMtrReading"]
-                data["billStartDate"] = r["CurrentUsage"]["billStartDate"]
+                data["projectedKWH"] = r["CurrentUsage"].get("projectedKWH")
+                data["dailyAverageKWH"] = r["CurrentUsage"].get("dailyAverageKWH")
+                data["billToDateKWH"] = r["CurrentUsage"].get("billToDateKWH")
+                data["recMtrReading"] = r["CurrentUsage"].get("recMtrReading")
+                data["delMtrReading"] = r["CurrentUsage"].get("delMtrReading")
+                data["billStartDate"] = r["CurrentUsage"].get("billStartDate")
         return data
 
     async def __getDataFromApplianceUsage(self, account, lastBilledDate) -> dict:

--- a/custom_components/fpl/sensor_KWHSensor.py
+++ b/custom_components/fpl/sensor_KWHSensor.py
@@ -29,7 +29,7 @@ class ProjectedKWHSensor(FplEntity):
 
 class DailyAverageKWHSensor(FplEntity):
     def __init__(self, coordinator, config, account):
-        super().__init__(coordinator, config, account, "Daily Average")
+        super().__init__(coordinator, config, account, "Daily Average KWH")
 
     @property
     def state(self):


### PR DESCRIPTION
First, thanks for the great custom component! I was so relieved this already existed. 

I was having some issues logging in, like I see a few others are, because of the finicky FPL API sometimes not returning all the data and then the code throwing a `keyError`. This was happening to me in the daily attributes as well as in the `currentUsage` attributes (sometimes). I replaced the bracket notation with `.get`, which will default the value to `None` if it is not present. Home Assistant will just handle that as an `Unknown` value. I figured this was preferable to defaulting to 0, since 0 could be mistaken for a valid measurement. 

Also, the `DailyAverageKWHSensor` was being ignored by Home Assistant because it was registering its name as just "Daily Average", which was already registered by the `FplAverageDailySensor`, so I tweaked the name there to "Daily Average KWH". 