### PR TITLE
RE:  Support for new Home Assistant Energy Managment and Stats #16 

### DIFF
--- a/custom_components/fpl/__init__.py
+++ b/custom_components/fpl/__init__.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
@@ -15,6 +16,7 @@ from .fplapi import FplApi
 from .const import (
     DOMAIN,
     DOMAIN_DATA,
+    NAME,
     PLATFORMS,
     STARTUP_MESSAGE,
 )
@@ -25,6 +27,14 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 _LOGGER = logging.getLogger(__package__)
 
+def get_device_info():
+    return DeviceInfo(
+        identifiers={
+            ("id", NAME),
+        },
+        name=NAME,
+        manufacturer=NAME,
+    )
 
 class FplData:
     """This class handle communication and stores the data."""

--- a/custom_components/fpl/sensor.py
+++ b/custom_components/fpl/sensor.py
@@ -31,7 +31,16 @@ from .sensor_DailyUsageSensor import (
     FplDailyUsageSensor,
     FplDailyDeliveredKWHSensor,
     FplDailyReceivedKWHSensor,
+    FplDailyDeliveredReading,
+    FplDailyReceivedReading,
 )
+#from .sensor_HourlyUsageSensor import (
+#    FplHourlyUsageSensor,
+#    FplHourlyUsageKWHSensor,
+#    FplHourlyReceivedKWHSensor,
+#    FplHourlyDeliveredKWHSensor,
+#    FplHourlyReadingKWHSensor
+#)
 
 from .sensor_BalanceSensor import BalanceSensor
 
@@ -85,6 +94,15 @@ registerSensor(NetReceivedKWHSensor, ONLY_MAINREGION)
 registerSensor(NetDeliveredKWHSensor, ONLY_MAINREGION)
 registerSensor(FplDailyReceivedKWHSensor, ONLY_MAINREGION)
 registerSensor(FplDailyDeliveredKWHSensor, ONLY_MAINREGION)
+registerSensor(FplDailyDeliveredReading, ONLY_MAINREGION)
+registerSensor(FplDailyReceivedReading, ONLY_MAINREGION)
+
+#hourly sensors
+# registerSensor(FplHourlyUsageSensor, ONLY_MAINREGION)
+# registerSensor(FplHourlyUsageKWHSensor, ONLY_MAINREGION)
+# registerSensor(FplHourlyReceivedKWHSensor, ONLY_MAINREGION)
+# registerSensor(FplHourlyDeliveredKWHSensor, ONLY_MAINREGION)
+# registerSensor(FplHourlyReadingKWHSensor, ONLY_MAINREGION)
 
 # Balance sensors
 registerSensor(BalanceSensor, ONLY_MAINREGION)

--- a/custom_components/fpl/sensor_DailyUsageSensor.py
+++ b/custom_components/fpl/sensor_DailyUsageSensor.py
@@ -2,6 +2,7 @@
 from datetime import timedelta, datetime
 from homeassistant.components.sensor import (
     STATE_CLASS_TOTAL_INCREASING,
+    STATE_CLASS_TOTAL,
     DEVICE_CLASS_ENERGY,
 )
 from .fplEntity import FplEnergyEntity, FplMoneyEntity
@@ -39,7 +40,7 @@ class FplDailyUsageKWHSensor(FplEnergyEntity):
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Daily Usage KWH")
 
-    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_state_class = STATE_CLASS_TOTAL
     _attr_device_class = DEVICE_CLASS_ENERGY
 
     @property
@@ -81,7 +82,8 @@ class FplDailyReceivedKWHSensor(FplEnergyEntity):
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Daily Received KWH")
 
-    # _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_state_class = STATE_CLASS_TOTAL
+    _attr_device_class = DEVICE_CLASS_ENERGY
 
     @property
     def native_value(self):
@@ -92,6 +94,17 @@ class FplDailyReceivedKWHSensor(FplEnergyEntity):
 
         return self._attr_native_value
 
+    @property
+    def last_reset(self) -> datetime | None:
+        data = self.getData("daily_usage")
+        if data is not None and len(data) > 0 and "netReceivedKwh" in data[-1].keys():
+            date = data[-1]["readTime"]
+            _attr_last_reset = date - timedelta(days=1)
+        else:
+            _attr_last_reset = None
+
+        return _attr_last_reset
+        
     def customAttributes(self):
         """Return the state attributes."""
         data = self.getData("daily_usage")
@@ -108,7 +121,8 @@ class FplDailyReceivedKWHSensor(FplEnergyEntity):
 class FplDailyDeliveredKWHSensor(FplEnergyEntity):
     """daily delivered Kwh sensor"""
 
-    # _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_state_class = STATE_CLASS_TOTAL
+    _attr_device_class = DEVICE_CLASS_ENERGY
 
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Daily Delivered KWH")
@@ -121,6 +135,17 @@ class FplDailyDeliveredKWHSensor(FplEnergyEntity):
             self._attr_native_value = data[-1]["netDeliveredKwh"]
 
         return self._attr_native_value
+    
+    @property
+    def last_reset(self) -> datetime | None:
+        data = self.getData("daily_usage")
+        if data is not None and len(data) > 0 and "netDeliveredKwh" in data[-1].keys():
+            date = data[-1]["readTime"]
+            _attr_last_reset = date - timedelta(days=1)
+        else:
+            _attr_last_reset = None
+
+        return _attr_last_reset
 
     def customAttributes(self):
         """Return the state attributes."""

--- a/custom_components/fpl/sensor_DailyUsageSensor.py
+++ b/custom_components/fpl/sensor_DailyUsageSensor.py
@@ -157,3 +157,40 @@ class FplDailyDeliveredKWHSensor(FplEnergyEntity):
             attributes["date"] = date
             # attributes["last_reset"] = last_reset
         return attributes
+
+#jf changes below
+class FplDailyReceivedReading(FplEnergyEntity):
+    """daily received reading"""
+
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class = DEVICE_CLASS_ENERGY
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Daily Received reading")
+
+    @property
+    def native_value(self):
+        data = self.getData("daily_usage")
+
+        if data is not None and len(data) > 0 and "netReceivedReading" in data[-1].keys():
+            self._attr_native_value = data[-1]["netReceivedReading"]
+
+        return self._attr_native_value
+        
+class FplDailyDeliveredReading(FplEnergyEntity):
+    """daily delivered reading"""
+
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class = DEVICE_CLASS_ENERGY
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Daily Delivered reading")
+
+    @property
+    def native_value(self):
+        data = self.getData("daily_usage")
+
+        if data is not None and len(data) > 0 and "netDeliveredReading" in data[-1].keys():
+            self._attr_native_value = data[-1]["netDeliveredReading"]
+
+        return self._attr_native_value

--- a/custom_components/fpl/sensor_HourlyUsageSensor.py
+++ b/custom_components/fpl/sensor_HourlyUsageSensor.py
@@ -1,0 +1,183 @@
+"""Hourly Usage Sensors"""
+from datetime import timedelta, datetime
+from homeassistant.components.sensor import (
+    STATE_CLASS_TOTAL_INCREASING,
+    STATE_CLASS_TOTAL,
+    DEVICE_CLASS_ENERGY,
+)
+from .fplEntity import FplEnergyEntity, FplMoneyEntity
+#from homeassistant_historical_sensor import (
+#    HistoricalSensor, HistoricalState, PollUpdateMixin,
+#)
+
+
+class FplHourlyUsageSensor(FplMoneyEntity):
+    """Hourly Usage Cost Sensor"""
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Hourly Usage")
+
+    @property
+    def native_value(self):
+        data = self.getData("hourly_usage")
+
+        if data is not None and len(data) > 0 and "cost" in data[-1].keys():
+            self._attr_native_value = data[-1]["cost"]
+
+        return self._attr_native_value
+
+    def customAttributes(self):
+        """Return the state attributes."""
+        data = self.getData("hourly_usage")
+        attributes = {}
+
+        if data is not None and len(data) > 0 and "readTime" in data[-1].keys():
+            attributes["date"] = data[-1]["readTime"]
+
+        return attributes
+
+
+class FplHourlyUsageKWHSensor(FplEnergyEntity):
+    """Hourly Usage Kwh Sensor"""
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Hourly Usage KWH")
+
+    # _attr_state_class = STATE_CLASS_TOTAL
+    _attr_device_class = DEVICE_CLASS_ENERGY
+
+    @property def statistic_id(self) -> str:
+        return self.entity_id
+        
+    #@property
+    #def native_value(self):
+    #    data = self.getData("hourly_usage")
+
+    #    if data is not None and len(data) > 0 and "kwhActual" in data[-1].keys():
+    #        self._attr_native_value = data[-1]["kwhActual"]
+
+    #    return self._attr_native_value
+
+    #@property
+    #def last_reset(self) -> datetime | None:
+    #    data = self.getData("hourly_usage")
+    #    if data is not None and len(data) > 0 and "readTime" in data[-1].keys():
+    #        date = data[-1]["readTime"]
+    #        _attr_last_reset = date
+    #    else:
+    #        _attr_last_reset = None
+
+    #    return _attr_last_reset
+
+    def customAttributes(self):
+ 
+        attributes = {}
+ 
+        return attributes
+
+
+class FplHourlyReceivedKWHSensor(FplEnergyEntity):
+    """hourly received Kwh sensor"""
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Hourly Received KWH")
+
+    def get_statistic_metadata(self) -> StatisticMetaData:
+        meta = super().get_statistic_metadata() meta["has_sum"] = True
+        meta["has_mean"] = True
+
+        return meta
+        
+    # _attr_state_class = STATE_CLASS_TOTAL
+    _attr_device_class = DEVICE_CLASS_ENERGY
+    
+    @property def statistic_id(self) -> str:
+        return self.entity_id
+        
+
+    #@property
+    #def native_value(self):
+    #    data = self.getData("hourly_usage")
+
+    #    if data is not None and len(data) > 0 and "netReceived" in data[-1].keys():
+    #        self._attr_native_value = data[-1]["netReceived"]
+
+    #    return self._attr_native_value
+
+    #@property
+    #def last_reset(self) -> datetime | None:
+    #    data = self.getData("hourly_usage")
+    #    if data is not None and len(data) > 0 and "readTime" in data[-1].keys():
+    #        date = data[-1]["readTime"]
+    #        _attr_last_reset = date
+    #    else:
+    #        _attr_last_reset = None
+
+    #    return _attr_last_reset
+        
+    def customAttributes(self):
+  
+        attributes = {}
+
+        return attributes
+
+
+class FplHourlyDeliveredKWHSensor(FplEnergyEntity):
+    """hourly delivered Kwh sensor"""
+
+    #_attr_state_class = STATE_CLASS_TOTAL
+    _attr_device_class = DEVICE_CLASS_ENERGY
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Hourly Delivered KWH")
+
+    #@property
+    #def native_value(self):
+    #    data = self.getData("hourly_usage")
+
+    #    if data is not None and len(data) > 0 and "netDelivered" in data[-1].keys():
+    #        self._attr_native_value = data[-1]["netDelivered"]
+
+    #    return self._attr_native_value
+
+    #@property
+    #def last_reset(self) -> datetime | None:
+    #    data = self.getData("hourly_usage")
+    #    if data is not None and len(data) > 0 and "readTime" in data[-1].keys():
+    #        date = data[-1]["readTime"]
+    #        _attr_last_reset = date
+    #    else:
+    #        _attr_last_reset = None
+
+    #    return _attr_last_reset
+        
+    def customAttributes(self):
+
+        attributes = {}
+
+        return attributes
+
+class FplHourlyReadingKWHSensor(FplEnergyEntity):
+    """hourly reading Kwh sensor"""
+
+    #_attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class = DEVICE_CLASS_ENERGY
+
+    def __init__(self, coordinator, config, account):
+        super().__init__(coordinator, config, account, "Hourly reading KWH")
+
+    #@property
+    #def native_value(self):
+    #    data = self.getData("hourly_usage")
+
+    #    if data is not None and len(data) > 0 and "reading" in data[-1].keys():
+    #        self._attr_native_value = data[-1]["reading"]
+
+    #    return self._attr_native_value
+
+ 
+    def customAttributes(self):
+
+        attributes = {}
+
+        return attributes

--- a/custom_components/fpl/sensor_KWHSensor.py
+++ b/custom_components/fpl/sensor_KWHSensor.py
@@ -79,6 +79,9 @@ class NetReceivedKWHSensor(FplEnergyEntity):
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Received Meter Reading KWH")
 
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class = DEVICE_CLASS_ENERGY
+    
     @property
     def native_value(self):
         recMtrReading = self.getData("recMtrReading")
@@ -101,6 +104,9 @@ class NetDeliveredKWHSensor(FplEnergyEntity):
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Delivered Meter Reading KWH")
 
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+    _attr_device_class = DEVICE_CLASS_ENERGY
+    
     @property
     def native_value(self):
         delMtrReading = self.getData("delMtrReading")


### PR DESCRIPTION
Makes sensors for Daily Usage KWH, Daily Received KWH, and Daily Delivered KWH hours in correct format (Class=Total + Energy) to use in energy dashboard. Added last_reset where not set. Not 100% certain if it works properly. My HA seems to add daily received and daily delivered each hour instead of each day. So, it skews my energy usage by several multiples.

I am attempting to use a **utility meter helper** with the daily received/delivered KWH. Created one for each. Looks promising. Energy dashboard sees it.
 

>      {
>         "entry_id": "xxxxxxx",
>         "version": 2,
>         "minor_version": 1,
>         "domain": "utility_meter",
>         "title": "kwh_received",
>         "data": {},
>         "options": {
>           "name": "kwh_received",
>           "source": "sensor.fpl_xxxxxxxxxx_daily_received_kwh",
>           "cycle": "daily",
>           "offset": 0.0,
>           "tariffs": [],
>           "net_consumption": false,
>           "delta_values": false,
>           "periodically_resetting": true,
>           "always_available": false
>         },
>         "pref_disable_new_entities": false,
>         "pref_disable_polling": false,
>         "source": "user",
>         "unique_id": null,
>         "disabled_by": null
>       },
>       {
>         "entry_id": "xxxxxxxxxx",
>         "version": 2,
>         "minor_version": 1,
>         "domain": "utility_meter",
>         "title": "kwh_delivered",
>         "data": {},
>         "options": {
>           "name": "kwh_delivered",
>           "source": "sensor.fpl_xxxxxxxxxx_daily_delivered_kwh",
>           "cycle": "daily",
>           "offset": 0.0,
>           "tariffs": [],
>           "net_consumption": false,
>           "delta_values": false,
>           "periodically_resetting": true,
>           "always_available": false
>         },
>         "pref_disable_new_entities": false,
>         "pref_disable_polling": false,
>         "source": "user",
>         "unique_id": null,
>         "disabled_by": null
>       }

Also makes Net Received KWH and Net Delivered KWH usable to the energy dashboard also. These appear only to be updated monthly. Not sure how useful these will be.
  
 EDIT:
 The meter helpers do not work. There seems to be a short period when the data is being updated from FPL (each poll) that the values become unvavailable. This appears to cause the meter to add the value to previous when it is updated. Instead calcuating receieved/delivered at 10x or more of the actual usage.