### PR TITLE
Remove account to sync with sensors

### DIFF
--- a/custom_components/fpl/fplEntity.py
+++ b/custom_components/fpl/fplEntity.py
@@ -39,7 +39,7 @@ class FplEntity(CoordinatorEntity, SensorEntity):
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.account)},
-            "name": f"FPL Account {self.account}",
+            "name": f"FPL {self.account}",
             "model": VERSION,
             "manufacturer": "Florida Power & Light",
         }


### PR DESCRIPTION
When the account and sensor names align, we won't  need to see the account on every sensor
Eg. See screenshot

![Screenshot_20241010-073348~2](https://github.com/user-attachments/assets/0c2bcde2-1ee6-4adc-b35c-9b63475437b2)
