### PR TITLE
Hourly Usage: All 24 hours now shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This repo uses `uv` for Python package dependencies.
 2. Run `uv venv`
 3. Run `uv sync --dev`
 4. Run `./scripts/develop`. This will start Home Assistant locally.
-5. Access HAOS `http://localhost:8321`
+5. Access HAOS `http://localhost:8123`
 6. If asked, setup Home Assistant for the first time.
 7. Go to Settings > Device & Services > Add Integrations, and create a new FPL integration.
 8. Make changes to the source code and restart HAOS to take effect.

--- a/custom_components/fpl/FplMainRegionApiClient.py
+++ b/custom_components/fpl/FplMainRegionApiClient.py
@@ -384,7 +384,7 @@ class FplMainRegionApiClient:
             + f"/cs/customer/v1/energydashboard/resources/energy-usage/account/{account}/mobile-hourly-usage"
         )
 
-        JSON = {"premiseNumber": premise, "startDate": date.strftime("%m-%d-%Y")}
+        JSON = {"premiseNumber": premise, "startDate": date.strftime("%m-%d-%Y"), "endDate": date.strftime("%m-%d-%Y")}
 
         data = []
         try:


### PR DESCRIPTION
Hourly Usage: All 24 hours are now shown. This required only a single line to be corrected.

Also corrected an error in the README.md file that listed an incorrect port number.

Edit: Related to [this issue](https://github.com/dotKrad/hass-fpl/issues/67)

Edit2: Credit where credit is due, the real author behind this fix was Claude Haiku through VS_Code. Cost 24.2 credits :)

Here's its explanation:

The Problem:
The API request was only sending a startDate parameter without an endDate parameter:

The Fix:
The FPL API's [mobile-hourly-usage](vscode-file://vscode-app/c:/Users/janst/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint requires both startDate and endDate parameters to properly return all 24 hours of data. Without the endDate, the API was defaulting to returning only 20 hours.

What I Changed:
I updated the JSON payload to include the endDate parameter (set to the same date as startDate for a single day):

This tells the API to fetch hourly usage data for the entire day, which should now return all 24 hours instead of the first 20. The last four hours should no longer be blank.