### PR TITLE
Fix balance parsing when balancesDrilldown is absent

### DIFF
--- a/custom_components/fpl/FplMainRegionApiClient.py
+++ b/custom_components/fpl/FplMainRegionApiClient.py
@@ -482,26 +482,47 @@ class FplMainRegionApiClient:
                 json_data = await response.json()
                 if response.status == 200:
                     for account in json_data["data"]["AccountList"]["data"]:
-                        if account["accountNumber"] == account_number:
-                            balances = account["balancesDrilldown"]["data"]
+                        if account["accountNumber"] != account_number:
+                            continue
 
-                            if len(balances) == 0:
-                                continue
+                        balances_drilldown = account.get("balancesDrilldown")
+                        if balances_drilldown:
+                            balances = balances_drilldown.get("data") or []
+                            if balances:
+                                amount = balances[0].get("amount")
+                                if amount:
+                                    data["balance"] = float(
+                                        amount.replace("$", "").replace(",", "")
+                                    )
+                                due_date = balances[0].get("dueDate")
+                                if due_date:
+                                    try:
+                                        data["balance_due_date"] = datetime.strptime(
+                                            due_date, "%b %d, %Y"
+                                        ).date()
+                                    except ValueError:
+                                        pass
+                            break
 
-                            balance = balances[0]["amount"]
+                        actual_balance = account.get("actualBalance")
+                        if actual_balance is not None:
+                            data["balance"] = float(actual_balance)
+                        elif account.get("balance") is not None:
+                            data["balance"] = float(
+                                str(account["balance"])
+                                .replace("$", "")
+                                .replace(",", "")
+                            )
 
-                            balance = balance.replace("$", "")
-                            balance = balance.replace(",", "")
-                            balance = float(balance)
-
-                            data["balance"] = balance
-
-                            # Due Date is provided like this `Dec 22, 2025` we need to convert this to a date.
-                            balance_due_date = balances[0]["dueDate"]
-                            balance_due_date = datetime.strptime(
-                                balance_due_date, "%b %d, %Y"
-                            ).date()
-                            data["balance_due_date"] = balance_due_date
+                        due_date_val = account.get("dueDateVal")
+                        if due_date_val:
+                            try:
+                                data["balance_due_date"] = datetime.strptime(
+                                    due_date_val, "%b %d, %Y"
+                                ).date()
+                            except ValueError:
+                                pass
+                        break
 
                 return data
 

--- a/custom_components/fpl/fplapi.py
+++ b/custom_components/fpl/fplapi.py
@@ -20,7 +20,6 @@ from .const import (
 from .FplMainRegionApiClient import FplMainRegionApiClient
 from .FplNorthwestRegionApiClient import FplNorthwestRegionApiClient
 
-
 _LOGGER = logging.getLogger(__package__)
 
 

--- a/custom_components/fpl/translations/en.json
+++ b/custom_components/fpl/translations/en.json
@@ -4,7 +4,7 @@
         "step": {
             "user": {
                 "title": "Florida Power & Light",
-                "description": "If you need help with the configuration have a look here: https://github.com/dotKrad/hass-fpl",
+                "description": "Enter your FPL web account credentials.",
                 "data": {
                     "name": "Name",
                     "username": "Email",


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 'balancesDrilldown'` when fetching account balance from FPL's `loginNew` endpoint
- FPL now returns balance data as flat fields on each account (`actualBalance`, `balance`, `dueDateVal`) instead of nested `balancesDrilldown.data`
- Keeps legacy `balancesDrilldown` parsing for backward compatibility
- Skips `balance_due_date` when `dueDateVal` is a non-date message (e.g. "Your account is paid in full.")

Fixes #68

## Context

Captured via mitmproxy from the FPL iOS app (June 2026): `POST /cs/customer/v1/accountservices/resources/loginNew` returns accounts without `balancesDrilldown`. The integration was crashing in `get_account_details()` and balance sensors stayed unavailable.

## Test plan

- [ ] Log in with an account where `loginNew` returns flat balance fields (no `balancesDrilldown`)
- [ ] Confirm balance sensor shows a numeric value (not unavailable)
- [ ] Confirm no `KeyError: 'balancesDrilldown'` in logs
- [ ] Confirm balance due date sensor is unavailable (not crashing) when `dueDateVal` is a text message
- [ ] If possible, verify accounts that still return `balancesDrilldown` continue to work


Made with [Cursor](https://cursor.com)