### PR TITLE
Fix multi-account discovery and per-account update failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ See estimated usage and cost by appliance category:
 3. Search for **"FPL"**
 4. Enter your FPL account credentials
 
+### Energy Dashboard
+
+Hourly data for the Energy Dashboard comes from **external statistics**, not the Hourly Usage sensors (those stay Unknown and are for debugging only).
+
+1. Go to **Settings** → **Dashboards** → **Energy** → **Configuration**.
+2. Under grid consumption, pick the **statistics** entries (chart icon), not the sensor entities (lightning icon):
+   - `FPL <account> Hourly Usage` → statistic ID `fpl:<account>_hourly_usage`
+   - `FPL <account> Hourly Cost` → statistic ID `fpl:<account>_hourly_cost`
+3. Replace `<account>` with your FPL account number. On first setup, wait a few minutes for the integration to backfill hourly data before expecting charts to populate.
+
 ---
 
 ## Development

--- a/custom_components/fpl/FplMainRegionApiClient.py
+++ b/custom_components/fpl/FplMainRegionApiClient.py
@@ -139,11 +139,22 @@ class FplMainRegionApiClient:
 
             json_data = await response.json()
             if response.status != 200:
+                _LOGGER.warning(
+                    "Account list request failed with status %s at start=%s",
+                    response.status,
+                    start,
+                )
                 break
 
-            for account in json_data.get("data", []):
+            accounts_page = json_data.get("data", [])
+            if not accounts_page:
+                break
+
+            for account in accounts_page:
                 if account.get("statusCategory") == STATUS_CATEGORY_OPEN:
-                    result.append(account["accountNumber"])
+                    account_number = account.get("accountNumber")
+                    if account_number:
+                        result.append(account_number)
 
             if not json_data.get("hasMore"):
                 break
@@ -242,7 +253,7 @@ class FplMainRegionApiClient:
                         data.update(appliance_usage_data)
 
         except Exception as e:
-            _LOGGER.error("Failed to update account %s: %s", account, e)
+            _LOGGER.error("Failed to update account %s: %s", account, e, exc_info=True)
 
         data.update(await self.get_account_details(account))
 
@@ -604,6 +615,8 @@ class FplMainRegionApiClient:
                 return data
 
         except Exception as e:
-            _LOGGER.error(e)
+            _LOGGER.error(
+                "Failed to get account details for %s", account_number, exc_info=True
+            )
 
         return data

--- a/custom_components/fpl/FplMainRegionApiClient.py
+++ b/custom_components/fpl/FplMainRegionApiClient.py
@@ -124,20 +124,31 @@ class FplMainRegionApiClient:
         Returns array with active account numbers
         """
         result = []
-        URL = API_HOST + "/cs/customer/v1/resources/header"
+        URL = API_HOST + "/cs/customer/v1/resources/account"
         headers = {}
         if hasattr(self, "jwt_token") and self.jwt_token:
             headers["jwttoken"] = self.jwt_token
 
-        async with async_timeout.timeout(TIMEOUT):
-            response = await self.session.get(URL, headers=headers)
+        start = 1
+        page_size = 10
 
-        json_data = await response.json()
-        accounts = json_data["data"]["accounts"]["data"]["data"]
+        while True:
+            params = {"sortBy": "status", "count": str(page_size), "start": str(start)}
+            async with async_timeout.timeout(TIMEOUT):
+                response = await self.session.get(URL, headers=headers, params=params)
 
-        for account in accounts:
-            if account["statusCategory"] == STATUS_CATEGORY_OPEN:
-                result.append(account["accountNumber"])
+            json_data = await response.json()
+            if response.status != 200:
+                break
+
+            for account in json_data.get("data", []):
+                if account.get("statusCategory") == STATUS_CATEGORY_OPEN:
+                    result.append(account["accountNumber"])
+
+            if not json_data.get("hasMore"):
+                break
+
+            start += json_data.get("count", page_size)
 
         return result
 
@@ -159,70 +170,80 @@ class FplMainRegionApiClient:
             API_HOST
             + "/cs/customer/v1/accountservices/resources/account/{account}/select?view=account-lander"
         )
-        headers = {}
-        if hasattr(self, "jwt_token") and self.jwt_token:
-            headers["jwttoken"] = self.jwt_token
-        async with async_timeout.timeout(TIMEOUT):
-            response = await self.session.get(
-                URL_RESOURCES_ACCOUNT.format(account=account), headers=headers
-            )
-        account_data = (await response.json())["data"]
+        try:
+            headers = {}
+            if hasattr(self, "jwt_token") and self.jwt_token:
+                headers["jwttoken"] = self.jwt_token
+            async with async_timeout.timeout(TIMEOUT):
+                response = await self.session.get(
+                    URL_RESOURCES_ACCOUNT.format(account=account), headers=headers
+                )
+            account_data = (await response.json()).get("data")
+            if account_data:
+                premise_number = account_data.get("premiseNumber")
+                premise = None
+                if premise_number:
+                    premise = str(premise_number).zfill(9)
+                    data["premise"] = premise
 
-        premise = account_data.get("premiseNumber").zfill(9)
-        data["premise"] = premise
+                if account_data.get("meterSerialNo") is not None:
+                    data["meterSerialNo"] = account_data["meterSerialNo"]
+                meterno = account_data.get("meterNo")
 
-        data["meterSerialNo"] = account_data["meterSerialNo"]
-        # data["meterNo"] = account_data["meterNo"]
-        meterno = account_data["meterNo"]
+                current_bill_date_raw = account_data.get("currentBillDate")
+                next_bill_date_raw = account_data.get("nextBillDate")
+                if current_bill_date_raw and next_bill_date_raw:
+                    currentBillDate = datetime.strptime(
+                        current_bill_date_raw.replace("-", "").split("T")[0], "%Y%m%d"
+                    ).date()
 
-        # currentBillDate
-        currentBillDate = datetime.strptime(
-            account_data["currentBillDate"].replace("-", "").split("T")[0], "%Y%m%d"
-        ).date()
+                    nextBillDate = datetime.strptime(
+                        next_bill_date_raw.replace("-", "").split("T")[0], "%Y%m%d"
+                    ).date()
 
-        # nextBillDate
-        nextBillDate = datetime.strptime(
-            account_data["nextBillDate"].replace("-", "").split("T")[0], "%Y%m%d"
-        ).date()
+                    data["current_bill_date"] = str(currentBillDate)
+                    data["next_bill_date"] = str(nextBillDate)
 
-        data["current_bill_date"] = str(currentBillDate)
-        data["next_bill_date"] = str(nextBillDate)
+                    today = datetime.now().date()
 
-        today = datetime.now().date()
+                    data["service_days"] = (nextBillDate - currentBillDate).days
+                    data["as_of_days"] = (today - currentBillDate).days
+                    data["remaining_days"] = (nextBillDate - today).days
 
-        data["service_days"] = (nextBillDate - currentBillDate).days
-        data["as_of_days"] = (today - currentBillDate).days
-        data["remaining_days"] = (nextBillDate - today).days
+                    programsData = account_data.get("programs", {}).get("data", [])
 
-        programsData = account_data["programs"]["data"]
+                    programs = dict()
+                    _LOGGER.info("Getting Programs")
+                    for program in programsData:
+                        if "enrollmentStatus" in program.keys():
+                            key = program["name"]
+                            programs[key] = program["enrollmentStatus"] == ENROLLED
 
-        programs = dict()
-        _LOGGER.info("Getting Programs")
-        for program in programsData:
-            if "enrollmentStatus" in program.keys():
-                key = program["name"]
-                programs[key] = program["enrollmentStatus"] == ENROLLED
+                    def hasProgram(programName) -> bool:
+                        return programName in programs and programs[programName]
 
-        def hasProgram(programName) -> bool:
-            return programName in programs and programs[programName]
+                    # Budget Billing program
+                    if hasProgram("BBL"):
+                        data["budget_bill"] = True
+                        bbl_data = await self.__getBBL_async(account, data)
+                        data.update(bbl_data)
+                    else:
+                        data["budget_bill"] = False
 
-        # Budget Billing program
-        if hasProgram("BBL"):
-            data["budget_bill"] = True
-            bbl_data = await self.__getBBL_async(account, data)
-            data.update(bbl_data)
-        else:
-            data["budget_bill"] = False
+                    if premise and meterno:
+                        energy_service_data = await self.get_energy_usage(
+                            account, premise, currentBillDate, meterno
+                        )
+                        data.update(energy_service_data)
 
-        energy_service_data = await self.get_energy_usage(
-            account, premise, currentBillDate, meterno
-        )
-        data.update(energy_service_data)
+                        appliance_usage_data = await self.get_appliance_usage(
+                            account, premise
+                        )
+                        data.update(appliance_usage_data)
 
-        appliance_usage_data = await self.get_appliance_usage(account, premise)
-        data.update(appliance_usage_data)
+        except Exception as e:
+            _LOGGER.error("Failed to update account %s: %s", account, e)
 
-        # Gets the account balance and past due status.
         data.update(await self.get_account_details(account))
 
         return data

--- a/custom_components/fpl/fplapi.py
+++ b/custom_components/fpl/fplapi.py
@@ -103,11 +103,7 @@ class FplApi:
 
             data[CONF_ACCOUNTS] = accounts
             for account in accounts:
-                try:
-                    data[account] = await self.apiClient.update(account)
-                except Exception as exception:
-                    _LOGGER.error("Error updating account %s: %s", account, exception)
-                    data[account] = {}
+                data[account] = await self.apiClient.update(account)
 
             await self.apiClient.logout()
         return data

--- a/custom_components/fpl/fplapi.py
+++ b/custom_components/fpl/fplapi.py
@@ -103,7 +103,11 @@ class FplApi:
 
             data[CONF_ACCOUNTS] = accounts
             for account in accounts:
-                data[account] = await self.apiClient.update(account)
+                try:
+                    data[account] = await self.apiClient.update(account)
+                except Exception as exception:
+                    _LOGGER.error("Error updating account %s: %s", account, exception)
+                    data[account] = {}
 
             await self.apiClient.logout()
         return data


### PR DESCRIPTION
## Summary

- Replaces the `/resources/header` account list with paginated `GET /resources/account?sortBy=status&count=10&start=…`, matching the FPL mobile app — fixes profiles with more than 3 linked accounts only returning the first page
- Hardens `update()` against missing `meterNo`, `premiseNumber`, and billing date fields (the reported crash at line 143)
- Isolates per-account update errors so one failing account does not abort the entire coordinator refresh
- Documents Energy Dashboard hourly statistics setup in README (`fpl:<account>_hourly_usage` / `_hourly_cost`)

Fixes #70

## Notes

Sensors are created from accounts discovered at initial setup. Users who previously set up the integration with a truncated account list may need to **delete and re-add** the integration to get sensors for newly discovered accounts.

## Test plan

- [x] Rebased on master (v1.0.3)
- [ ] Set up integration on a profile with 4+ linked accounts; confirm all open accounts appear
- [ ] Confirm coordinator updates succeed when one account has missing meter data
- [ ] Confirm energy/balance sensors populate for valid accounts