### PR TITLE
fix: handle HourlyUsage list response from mobile-hourly-usage

### DIFF
--- a/custom_components/fpl/FplMainRegionApiClient.py
+++ b/custom_components/fpl/FplMainRegionApiClient.py
@@ -399,12 +399,22 @@ class FplMainRegionApiClient:
                 )
                 if response.status == 200:
                     response_json = await response.json()
-                    json_data = response_json["data"]
-
-                    hourly_usage = json_data["HourlyUsage"]["data"]
+                    json_data = response_json.get("data") or {}
+                    hourly_usage_block = json_data.get("HourlyUsage")
+                    if isinstance(hourly_usage_block, list):
+                        hourly_usage = hourly_usage_block
+                    elif isinstance(hourly_usage_block, dict):
+                        hourly_usage = hourly_usage_block.get("data") or []
+                    else:
+                        hourly_usage = []
 
                     for hour_usage in hourly_usage:
-                        read_time = datetime.fromisoformat(hour_usage["readTime"])
+                        if not isinstance(hour_usage, dict):
+                            continue
+                        read_time_raw = hour_usage.get("readTime")
+                        if read_time_raw is None:
+                            continue
+                        read_time = datetime.fromisoformat(read_time_raw)
                         data.append(
                             {
                                 "hour": hour_usage.get(


### PR DESCRIPTION
## Summary

- Fixes `list indices must be integers or slices, not str` in `get_hourly_usage()` when FPL returns `HourlyUsage` as a top-level array instead of `{ "data": [...] }`
- Supports both response shapes for backward compatibility
- Skips hour entries without `readTime` (e.g. exception-only objects)

Fixes the hourly backfill crash reported after upgrading to v1.0.1. Related to #67.

## Context

PR #71 addressed a different symptom (missing last 4 hours via `endDate`) and was closed by the author when it did not reproduce in production. This PR targets the parsing crash only.

## Test plan

- [ ] Restart HA with this branch installed
- [ ] Confirm no `list indices must be integers or slices, not str` in logs from `FplMainRegionApiClient.py`
- [ ] Confirm hourly statistics backfill completes (check Energy dashboard external statistics entity)
- [ ] Confirm integration otherwise continues updating energy/balance sensors


Made with [Cursor](https://cursor.com)