### PR TITLE
Fix missing state class on Projected and Daily Average KWH sensors

### DIFF
--- a/custom_components/fpl/sensor_KWHSensor.py
+++ b/custom_components/fpl/sensor_KWHSensor.py
@@ -11,7 +11,7 @@ class ProjectedKWHSensor(FplEnergyEntity):
     # Use MEASUREMENT or TOTAL (without _INCREASING) as needed.
     # For now, let's assume it's a measurement of an estimation.
     _attr_device_class = SensorDeviceClass.ENERGY
-    # _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Projected KWH")
@@ -31,7 +31,7 @@ class DailyAverageKWHSensor(FplEnergyEntity):
 
     # Averages are often treated as measurements too, not cumulative totals.
     _attr_device_class = SensorDeviceClass.ENERGY
-    # _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, config, account):
         super().__init__(coordinator, config, account, "Daily Average KWH")


### PR DESCRIPTION
## Summary

Fixes #62

Restores `SensorStateClass.MEASUREMENT` on **Projected KWH** and **Daily Average KWH** sensors. The state class was commented out during a prior refactor, which caused Home Assistant to stop generating long-term statistics and prompt users to delete existing stats.

## Test plan

- [ ] Update integration with this branch
- [ ] Confirm `sensor.fpl_<account>_projected_kwh` and `sensor.fpl_<account>_daily_average_kwh` show `state_class: measurement` in Developer Tools → States
- [ ] Verify no "missing state class" warnings on startup
- [ ] Users who already deleted long-term statistics may need to wait for new data points to accumulate


Made with [Cursor](https://cursor.com)