### PR TITLE
fix: keep hourly backfill atomic

### DIFF
--- a/custom_components/fpl/fplDataUpdateCoordinator.py
+++ b/custom_components/fpl/fplDataUpdateCoordinator.py
@@ -151,7 +151,8 @@ class FplDataUpdateCoordinator(DataUpdateCoordinator):
                 return data
 
             yesterday = now.date() - timedelta(days=1)
-            if self._hourly_backfill_pending:
+            is_backfill = self._hourly_backfill_pending
+            if is_backfill:
                 target_dates = [
                     now.date() - timedelta(days=offset)
                     for offset in range(HOURLY_USAGE_BACKFILL_DAYS, 0, -1)
@@ -159,12 +160,17 @@ class FplDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 target_dates = [yesterday]
 
-            for account in data.get(CONF_ACCOUNTS, []):
+            accounts = data.get(CONF_ACCOUNTS, [])
+            backfill_complete = bool(accounts)
+            for account in accounts:
                 premise = data.get(account, {}).get("premise")
                 complete_dates = []
                 all_hourly = []
                 for target_date in target_dates:
-                    if (account, target_date) in self._finalized_hourly_dates:
+                    if (
+                        not is_backfill
+                        and (account, target_date) in self._finalized_hourly_dates
+                    ):
                         continue
                     hourly = await self.api.apiClient.get_hourly_usage(
                         account, premise, target_date
@@ -175,13 +181,18 @@ class FplDataUpdateCoordinator(DataUpdateCoordinator):
                     if len(target_dates) > 1:
                         await asyncio.sleep(1)
 
+                if is_backfill and len(complete_dates) != len(target_dates):
+                    backfill_complete = False
+                    continue
+
                 if all_hourly:
                     await self._publish_hourly_statistics(account, all_hourly)
                     self._finalized_hourly_dates.update(
                         (account, target_date) for target_date in complete_dates
                     )
 
-            self._hourly_backfill_pending = False
+            if is_backfill:
+                self._hourly_backfill_pending = not backfill_complete
 
             return data
         except Exception as exception:

--- a/tests/test_fpl_data_update_coordinator.py
+++ b/tests/test_fpl_data_update_coordinator.py
@@ -176,6 +176,42 @@ class HourlySchedulingTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_retries_entire_backfill_when_middle_day_is_incomplete(self):
+        today = date(2026, 7, 27)
+        incomplete_date = today - timedelta(days=7)
+        incomplete_returned = False
+
+        def hourly_response(_account, _premise, target):
+            nonlocal incomplete_returned
+            complete = target != incomplete_date or incomplete_returned
+            if target == incomplete_date:
+                incomplete_returned = True
+            return hourly_day(target, complete=complete)
+
+        coordinator = self.make_coordinator(hourly_response)
+        coordinator._hourly_backfill_pending = True
+
+        with (
+            patch.object(
+                coordinator_module.dt_util,
+                "now",
+                return_value=datetime(2026, 7, 27, 4, tzinfo=FPL_TIMEZONE),
+            ),
+            patch.object(coordinator_module.asyncio, "sleep", new=AsyncMock()),
+        ):
+            await coordinator._async_update_data()
+            self.assertTrue(coordinator._hourly_backfill_pending)
+            self.assertEqual(coordinator._publish_hourly_statistics.await_count, 0)
+
+            await coordinator._async_update_data()
+
+        self.assertFalse(coordinator._hourly_backfill_pending)
+        self.assertEqual(
+            coordinator.api.apiClient.get_hourly_usage.await_count,
+            HOURLY_USAGE_BACKFILL_DAYS * 2,
+        )
+        coordinator._publish_hourly_statistics.assert_awaited_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[#85](https://github.com/dotKrad/hass-fpl/issues/85)

## Summary
- defer the startup repair when any day in the 15-day window is incomplete
- retry the entire contiguous window instead of publishing across a missing date
- prevent false negative cumulative usage and cost values

## Root cause
A transiently incomplete July 24 response was skipped while later days were published. Their cumulative sums omitted July 24, producing a 107.73 kWh drop at midnight.

## Test plan
- [x] `uv run python -m unittest discover -s tests -v`
- [x] `uv run ruff check .`
- [x] `uv run black --check .`


Made with [Cursor](https://cursor.com)